### PR TITLE
Add $REPO_NAME and $PULL_REQUEST_ID to build env

### DIFF
--- a/config/default.xml.erb
+++ b/config/default.xml.erb
@@ -56,6 +56,10 @@ if [ ! -d &quot;./.git&quot; ]; then
 fi
 git fetch -q origin
 git reset -q --hard $JANKY_SHA1
+export REPO_NAME=$(git config --get remote.origin.url | cut -d: -f2 | cut -d. -f1)
+if [ -n "$REPO_NAME" ]; then
+  export PULL_REQUEST_ID=$(curl -H "Authorization: Bearer $GITHUB_ACCESS_TOKEN" https://api.github.com/repos/$REPO_NAME/pulls | jq "map(select(.head.sha == \"`echo $JANKY_SHA1`\"))[].number" | grep -o '[0-9]*')
+fi
 eval "$(rbenv init -)"
 rbenv alias --auto
 rbenv rehash


### PR DESCRIPTION
This adds two variables to the build environment the hard way:
- REPO_NAME is parsed from the origin.remote.url:
  `git@github.com:10to1/janky-10to1.git`
  -> 10to1/janky-10to1.git
  -> 10to1/janky-10to1
- PULL_REQUEST_ID is fetched from the github API.
  It uses GITHUB_ACCESS_TOKEN to access the api (this is needs to be set
  in CI) and calls and requests the open pull requests for an API.
  We use jq to parse the json.
  It compares the PR's head sha to the $JANKY_SHA1 set by janky. And
  selects `number` from this PR's json object.

If any of this fails, the script will just continue with the variables
unset. So be sure the check before using them.

This depends on
[10to1/preamble#10](https://github.com/10to1/preamble/pull/10)

I tried it out by adding these steps to a projects config manually.

If you want to use it for yours your going to have to shout `! ci setup
MY AWESUM PROJECT` at meechum.
